### PR TITLE
Parteds must be returned also as a list in API

### DIFF
--- a/bareon_api/api/controllers/partitioning.py
+++ b/bareon_api/api/controllers/partitioning.py
@@ -140,7 +140,7 @@ class PartitioningCotroller(rest.RestController):
 
         fss = models.FSS[node_id].values()
         lvs = models.LVS[node_id].values()
-        parteds = models.PARTEDS[node_id]
+        parteds = models.PARTEDS[node_id].values()
         pvs = models.PVS[node_id].values()
         vgs = models.VGS[node_id].values()
 


### PR DESCRIPTION
Parteds were returned as dict/json object were they should be a list.
